### PR TITLE
Localize UI and API messaging to Russian

### DIFF
--- a/src/401.twig
+++ b/src/401.twig
@@ -5,10 +5,10 @@
         <h2 class="headline text-warning"> 401</h2>
 
         <div class="error-content">
-            <h3><i class="fas fa-exclamation-triangle text-warning"></i> Sorry you don't have permission to view this page</h3>
+            <h3><i class="fas fa-exclamation-triangle text-warning"></i> К сожалению, у вас нет доступа к этой странице</h3>
 
             <p>
-                You might want to try checking you are in the right business if you have multiple businesses associated with your account.
+                Если к вашей учётной записи привязано несколько компаний, убедитесь, что выбрана нужная компания.
             </p>
         </div>
     </div>

--- a/src/api/account/basicDetails.php
+++ b/src/api/account/basicDetails.php
@@ -15,7 +15,7 @@ $DBLIB->where("users.users_deleted", 0);
 $DBLIB->where("users.users_suspended", 0);
 $DBLIB->where("users.users_userid", $userid);
 $currentUserData = $DBLIB->getone("users", ["users.*"]);
-if (!$currentUserData) finish(false, ["message" => "User not found error"]);
+if (!$currentUserData) finish(false, ["message" => "Пользователь не найден"]);
 
 $array["users_email"] = strtolower($array["users_email"]);
 $array["users_username"] = strtolower($array["users_username"]);
@@ -23,15 +23,15 @@ $array["users_username"] = strtolower($array["users_username"]);
 // Restrict the fields that can be edited
 $array = array_intersect_key($array, array_flip(["users_username", "users_name1", "users_name2", "users_email", "users_social_facebook", "users_social_twitter", "users_social_instagram", "users_social_linkedin", "users_social_snapchat"]));
 
-if ($array["users_email"] != $currentUserData["users_email"] and $AUTH->emailTaken($array["users_email"])) finish(false, ["message" => "Sorry this email is in use for another account"]);
-if ($array["users_username"] != $currentUserData["users_username"] and $AUTH->usernameTaken($array["users_username"])) finish(false, ["message" => "Sorry this username is in use for another account, please pick another"]);
+if ($array["users_email"] != $currentUserData["users_email"] and $AUTH->emailTaken($array["users_email"])) finish(false, ["message" => "Этот адрес эл. почты уже используется другой учётной записью"]);
+if ($array["users_username"] != $currentUserData["users_username"] and $AUTH->usernameTaken($array["users_username"])) finish(false, ["message" => "Это имя пользователя уже занято другой учётной записью, выберите другое"]);
 
 if ($array["users_email"] != $currentUserData["users_email"]) $array["users_emailVerified"] = 0;
 else $array["users_emailVerified"] = $currentUserData["users_emailVerified"];
 
 $DBLIB->where("users_userid", $userid);
 $result = $DBLIB->update("users", $array, 1);
-if (!$result) finish(false, ["code" => "UPDATE-FAIL", "message"=> "Could not update account details"]);
+if (!$result) finish(false, ["code" => "UPDATE-FAIL", "message"=> "Не удалось обновить данные учётной записи"]);
 else {
     if ($array["users_emailVerified"] == 0) $AUTH->verifyEmail($userid);
     $bCMS->auditLog("EDIT-ACCOUNT", "users", json_encode($array), $AUTH->data['users_userid'], $userid);

--- a/src/api/account/emailViewer.php
+++ b/src/api/account/emailViewer.php
@@ -1,8 +1,8 @@
 <?php
 require_once __DIR__ . '/../apiHeadSecure.php';
 header('Content-type: text/html');
-if (!$AUTH->serverPermissionCheck("USERS:VIEW:MAILINGS")) die("Sorry you don't have access to this");
-	$PAGEDATA['title'] = "E-Mail Viewer";
+if (!$AUTH->serverPermissionCheck("USERS:VIEW:MAILINGS")) die("К сожалению, у вас нет доступа к этому разделу");
+        $PAGEDATA['title'] = "Просмотр писем";
 	$output = '<style>
 					* {
 						font-family: sans-serif !important;
@@ -13,25 +13,25 @@ if (!$AUTH->serverPermissionCheck("USERS:VIEW:MAILINGS")) die("Sorry you don't h
 	if (isset($_POST['email']) and  $_POST['email'] != '') {
 		$DBLIB->where ('emailSent_id IN (' . $bCMS->sanitizeStringMYSQL($_POST['email']) . ')');
 		$emails = $DBLIB->get('emailSent');
-		if (!isset($emails[0])) die('E-Mail not found');
-	} else die('Nothing to see here!');
+                if (!isset($emails[0])) die('Письмо не найдено');
+        } else die('Нет данных для отображения!');
 	foreach ($emails as $email) {
 		$output .= '
 		<table border="0" style="width: 100%;">
 			<tr>
-				<td><b>From:</b></td>
+                                <td><b>От:</b></td>
 				<td>' . $email['emailSent_fromName'] . ' [' . $email['emailSent_fromEmail'] . ']'. '</td>
 			</tr>
 			<tr>
-				<td><b>Sent:</b></td>
-				<td>' . date("l, F j, Y h:i A", strtotime($email['emailSent_sent'])). ' - Email ID ' . $email['emailSent_id'] . '</td>
+                                <td><b>Отправлено:</b></td>
+                                <td>' . date("l, F j, Y h:i A", strtotime($email['emailSent_sent'])). ' — ID письма ' . $email['emailSent_id'] . '</td>
 			</tr>
 			<tr>
-				<td><b>To:</b></td>
+                                <td><b>Кому:</b></td>
 				<td>' . $email['emailSent_toName'] . ' (' . $email['users_userid'] . ') [' . $email['emailSent_toEmail'] . ']'. '</td>
 			</tr>
 			<tr>
-				<td><b>Subject:</b></td>
+                                <td><b>Тема:</b></td>
 				<td>' . $email['emailSent_subject']. '</td>
 			</tr>
 			<tr>

--- a/src/api/account/passwordReset.php
+++ b/src/api/account/passwordReset.php
@@ -12,8 +12,8 @@ $code = $DBLIB->getOne('passwordResetCodes');
 if (isset($code) and $code['passwordResetCodes_valid'] == '1') {
 	if (strtotime($code['passwordResetCodes_timestamp']) < (time() - (60 * 60 * 48))) { //48 hours
 		//Code has expired - send another
-		if ($AUTH->forgotPassword()) die("Sorry - Your code has expired - we've sent you another one instead");
-		else die("Sorry - Your code has expired - please try to create another code or contact the support team");
+                if ($AUTH->forgotPassword()) die("Срок действия вашего кода истёк — мы отправили вам новый");
+                else die("Срок действия вашего кода истёк — попробуйте создать новый код или обратитесь в службу поддержки");
 	}
 	$DBLIB->where('users_userid', $code['users_userid']);
 	$DBLIB->update('users', ["users_password" => "RESET", "users_changepass" => 1]); //Verify E-Mail

--- a/src/api/account/permissions.php
+++ b/src/api/account/permissions.php
@@ -1,8 +1,8 @@
 <?php
 require_once __DIR__ . '/../apiHeadSecure.php';
-if (!$AUTH->serverPermissionCheck("PERMISSIONS:EDIT:USER_POSITION")) die("Sorry - you can't access this page");
+if (!$AUTH->serverPermissionCheck("PERMISSIONS:EDIT:USER_POSITION")) die("К сожалению, у вас нет доступа к этой странице");
 
-if (!isset($_POST['action']) or !isset($_POST['users_userid']) or !isset($_POST["userPositions_id"])) finish(false, ["code" => null, "message"=> "Attribute error"]);
+if (!isset($_POST['action']) or !isset($_POST['users_userid']) or !isset($_POST["userPositions_id"])) finish(false, ["code" => null, "message"=> "Ошибка атрибутов"]);
 
 if ($_POST['action'] == "DELETE") {
     $DBLIB->where("users_userid", $bCMS->sanitizeString($_POST["users_userid"]));
@@ -10,9 +10,9 @@ if ($_POST['action'] == "DELETE") {
     if ($DBLIB->delete("userPositions")) {
         $bCMS->auditLog("DELETE", "userPositions", $bCMS->sanitizeString($_POST["userPositions_id"]), $AUTH->data['users_userid'],$bCMS->sanitizeString($_POST["users_userid"]));
         finish(true);
-    } else finish(false, ["code" => null, "message"=> "Delete error"]);
+    } else finish(false, ["code" => null, "message"=> "Ошибка удаления"]);
 } elseif ($_POST['action'] == "EDIT") {
-    if (strlen($_POST["userPositions_start"]) < 1 or strlen($_POST["userPositions_end"]) < 1 or strlen($_POST["userPositions_show"]) < 1) finish(false, ["code" => null, "message"=> "Attribute data error"]);
+    if (strlen($_POST["userPositions_start"]) < 1 or strlen($_POST["userPositions_end"]) < 1 or strlen($_POST["userPositions_show"]) < 1) finish(false, ["code" => null, "message"=> "Ошибка данных атрибутов"]);
     $data = [
         "users_userid"=>$bCMS->sanitizeString($_POST["users_userid"]),
         "positions_id"=>$bCMS->sanitizeString($_POST["positions_id"]),
@@ -24,16 +24,16 @@ if ($_POST['action'] == "DELETE") {
         if ($DBLIB->insert("userPositions",$data)) {
             $bCMS->auditLog("CREATE", "userPositions", json_encode($data), $AUTH->data['users_userid'],$bCMS->sanitizeString($_POST["users_userid"]));
             finish(true);
-        } else finish(false, ["code" => null, "message"=> "Insert error" . $DBLIB->getlastError()]);
+        } else finish(false, ["code" => null, "message"=> "Ошибка добавления" . $DBLIB->getlastError()]);
     } else {
         $DBLIB->where("users_userid", $bCMS->sanitizeString($_POST["users_userid"]));
         $DBLIB->where("userPositions_id", $bCMS->sanitizeString($_POST["userPositions_id"]));
         if ($DBLIB->update("userPositions",$data)) {
             $bCMS->auditLog("EDIT", "userPositions", $bCMS->sanitizeString($_POST["userPositions_id"]), $AUTH->data['users_userid'],$bCMS->sanitizeString($_POST["users_userid"]));
             finish(true);
-        } else finish(false, ["code" => null, "message"=> "Edit error"]);
+        } else finish(false, ["code" => null, "message"=> "Ошибка изменения"]);
     }
-} else finish(false, ["code" => null, "message"=> "Attribute action error"]);
+} else finish(false, ["code" => null, "message"=> "Некорректное действие"]);
 
 /** @OA\Post(
  *     path="/account/permissions.php", 

--- a/src/api/account/verifyEmail.php
+++ b/src/api/account/verifyEmail.php
@@ -13,8 +13,8 @@
 	if ($code) {
 		if (strtotime($code['emailVerificationCodes_timestamp']) < (time()-(60*60*48))) {
 			//Code has expired - send another
-            if ($AUTH->verifyEmail()) die("Sorry - Your code has expired - we've sent you another one instead");
-            else die("Sorry - Your code has expired - please try to create another code or contact the support team");
+            if ($AUTH->verifyEmail()) die("Срок действия вашего кода истёк — мы отправили вам новый");
+            else die("Срок действия вашего кода истёк — попробуйте создать новый код или обратитесь в службу поддержки");
         }
 		$DBLIB->where ('users_userid', $code['users_userid']);
 		$DBLIB->update ('users', ["users_emailVerified" => "1"]); //Verify E-Mail

--- a/src/api/account/viewSiteAs.php
+++ b/src/api/account/viewSiteAs.php
@@ -1,8 +1,8 @@
 <?php
 require_once __DIR__ . '/../apiHeadSecure.php';
 
-if (!$AUTH->serverPermissionCheck("USERS:VIEW_SITE_AS")) die("Sorry - you can't access this page");
-if (!(isset($_POST['userid']))) die("No uid passed");
+if (!$AUTH->serverPermissionCheck("USERS:VIEW_SITE_AS")) die("К сожалению, у вас нет доступа к этой странице");
+if (!(isset($_POST['userid']))) die("Не передан идентификатор пользователя");
 
 if ($AUTH->generateToken($bCMS->sanitizeString($_POST['userid']), $AUTH->data['users_userid'], "Web - View Site As", "web-session")) {
     $bCMS->auditLog("VIEWSITEAS", "users", null, $AUTH->data['users_userid'],$bCMS->sanitizeString($_POST['userid']));

--- a/src/api/assets/archive.php
+++ b/src/api/assets/archive.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../apiHeadSecure.php';
 
-if (!$AUTH->instancePermissionCheck("ASSETS:ARCHIVE")) die("Sorry - you can't access this page");
+if (!$AUTH->instancePermissionCheck("ASSETS:ARCHIVE")) die("К сожалению, у вас нет доступа к этой странице");
 
 if (!isset($_POST['assets_id'])) finish(false, ["code" => "PARAM-ERROR", "message"=> "No data for action"]);
 

--- a/src/api/assets/barcodes/assign.php
+++ b/src/api/assets/barcodes/assign.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../../apiHeadSecure.php';
 
-if (!$AUTH->instancePermissionCheck("ASSETS:ASSET_BARCODES:EDIT:ASSOCIATE_UNNASOCIATED_BARCODES_WITH_ASSETS")) die("Sorry - you can't access this page");
+if (!$AUTH->instancePermissionCheck("ASSETS:ASSET_BARCODES:EDIT:ASSOCIATE_UNNASOCIATED_BARCODES_WITH_ASSETS")) die("К сожалению, у вас нет доступа к этой странице");
 
 if (!isset($_POST['id'])) finish(false, ["code" => "PARAM-ERROR", "message" => "No data for action"]);
 

--- a/src/api/assets/barcodes/delete.php
+++ b/src/api/assets/barcodes/delete.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../../apiHeadSecure.php';
 
-if (!$AUTH->instancePermissionCheck("ASSETS:ASSET_BARCODES:DELETE")) die("Sorry - you can't access this page");
+if (!$AUTH->instancePermissionCheck("ASSETS:ASSET_BARCODES:DELETE")) die("К сожалению, у вас нет доступа к этой странице");
 
 if (!isset($_POST['barcodes_id'])) finish(false, ["code" => "PARAM-ERROR", "message"=> "No data for action"]);
 

--- a/src/api/assets/delete.php
+++ b/src/api/assets/delete.php
@@ -5,7 +5,7 @@ use Money\Currency;
 use Money\Money;
 use Money\Currencies\ISOCurrencies;
 use Money\Parser\DecimalMoneyParser;
-if (!$AUTH->instancePermissionCheck("ASSETS:DELETE")) die("Sorry - you can't access this page");
+if (!$AUTH->instancePermissionCheck("ASSETS:DELETE")) die("К сожалению, у вас нет доступа к этой странице");
 
 if (!isset($_POST['assets_id'])) finish(false, ["code" => "PARAM-ERROR", "message"=> "No data for action"]);
 

--- a/src/api/assets/editAsset.php
+++ b/src/api/assets/editAsset.php
@@ -6,7 +6,7 @@ use Money\Money;
 use Money\Currencies\ISOCurrencies;
 use Money\Parser\DecimalMoneyParser;
 
-if (!$AUTH->instancePermissionCheck("ASSETS:EDIT")) die("Sorry - you can't access this page");
+if (!$AUTH->instancePermissionCheck("ASSETS:EDIT")) die("К сожалению, у вас нет доступа к этой странице");
 $array = [];
 
 foreach ($_POST as $key=>$value) {
@@ -35,7 +35,7 @@ if (isset($array['assets_tag']) and $array['assets_tag'] != $asset['assets_tag']
     $DBLIB->where("assets.assets_tag", $array['assets_tag']);
     $DBLIB->where("assets.assets_deleted", 0); //Deleted assets can't be restored, so can be used
     $duplicateAssetTag = $DBLIB->getValue ("assets", "count(*)");
-    if ($duplicateAssetTag > 0) finish(false,["message" => "Sorry that Asset Tag is a duplicate of one already in your Business"]);
+    if ($duplicateAssetTag > 0) finish(false,["message" => "Этот инвентарный номер уже используется в вашей компании"]);
 }
 
 $DBLIB->where("assets_id", $array['assets_id']);

--- a/src/api/assets/editAssetType.php
+++ b/src/api/assets/editAssetType.php
@@ -5,7 +5,7 @@ use Money\Currency;
 use Money\Money;
 use Money\Currencies\ISOCurrencies;
 use Money\Parser\DecimalMoneyParser;
-if (!$AUTH->instancePermissionCheck("ASSETS:ASSET_TYPES:EDIT")) die("Sorry - you can't access this page");
+if (!$AUTH->instancePermissionCheck("ASSETS:ASSET_TYPES:EDIT")) die("К сожалению, у вас нет доступа к этой странице");
 
 $array = [];
 foreach ($_POST['formData'] as $item) {

--- a/src/api/assets/editAssetTypeDefinableFields.php
+++ b/src/api/assets/editAssetTypeDefinableFields.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../apiHeadSecure.php';
 
-if (!$AUTH->instancePermissionCheck("ASSETS:ASSET_TYPES:EDIT")) die("Sorry - you can't access this page");
+if (!$AUTH->instancePermissionCheck("ASSETS:ASSET_TYPES:EDIT")) die("К сожалению, у вас нет доступа к этой странице");
 
 $array = [];
 foreach ($_POST['formData'] as $item) {

--- a/src/api/assets/newAssetFromType.php
+++ b/src/api/assets/newAssetFromType.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../apiHeadSecure.php';
 
-if (!$AUTH->instancePermissionCheck("ASSETS:CREATE")) die("Sorry - you can't access this page");
+if (!$AUTH->instancePermissionCheck("ASSETS:CREATE")) die("К сожалению, у вас нет доступа к этой странице");
 $array = [];
 foreach ($_POST['formData'] as $item) {
     $array[$item['name']] = $item['value'];
@@ -21,7 +21,7 @@ if (isset($array['assets_tag']) and $array['assets_tag'] != null) {
     $DBLIB->where("assets.assets_tag", $array['assets_tag']);
     $DBLIB->where("assets.assets_deleted", 0); //Deleted assets can't be restored, so can be used
     $duplicateAssetTag = $DBLIB->getValue("assets", "count(*)");
-    if ($duplicateAssetTag > 0) finish(false, ["code" => "INSERT-FAIL", "message" => "Sorry that tag you chose was a duplicate - please choose another one"]);
+    if ($duplicateAssetTag > 0) finish(false, ["code" => "INSERT-FAIL", "message" => "Выбранный инвентарный номер уже используется — выберите другой"]);
 } else $array['assets_tag'] = generateNewTag();
 
 $result = $DBLIB->insert("assets", array_intersect_key($array, array_flip(['assets_tag', 'assetTypes_id', 'assets_notes', 'instances_id', 'asset_definableFields_1', 'asset_definableFields_2', 'asset_definableFields_3', 'asset_definableFields_4', 'asset_definableFields_5', 'asset_definableFields_6', 'asset_definableFields_7', 'asset_definableFields_8', 'asset_definableFields_9', 'asset_definableFields_10', 'assets_assetGroups'])));

--- a/src/api/assets/newAssetType.php
+++ b/src/api/assets/newAssetType.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../apiHeadSecure.php';
 
-if (!$AUTH->instancePermissionCheck("ASSETS:ASSET_TYPES:CREATE")) die("Sorry - you can't access this page");
+if (!$AUTH->instancePermissionCheck("ASSETS:ASSET_TYPES:CREATE")) die("К сожалению, у вас нет доступа к этой странице");
 
 $array = [];
 foreach ($_POST['formData'] as $item) {

--- a/src/api/instances/assetAssignmentStatus/reorder.php
+++ b/src/api/instances/assetAssignmentStatus/reorder.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../../apiHeadSecure.php';
 
-if (!$AUTH->instancePermissionCheck("BUSINESS:BUSINESS_SETTINGS:EDIT")) die("Sorry - you can't access this page");
+if (!$AUTH->instancePermissionCheck("BUSINESS:BUSINESS_SETTINGS:EDIT")) die("К сожалению, у вас нет доступа к этой странице");
 
 foreach ($_POST['order'] as $count=>$item) {
     if ($item == "") continue;

--- a/src/api/instances/billing/billingPortal.php
+++ b/src/api/instances/billing/billingPortal.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../../apiHeadSecure.php';
 
-if ($AUTH->data['users_userid'] !== $AUTH->data['instance']['instances_billingUser']) die("Sorry, you are not the billing contact for this business, please contact support.");
+if ($AUTH->data['users_userid'] !== $AUTH->data['instance']['instances_billingUser']) die("К сожалению, вы не являетесь плательщиком для этой компании. Свяжитесь с поддержкой.");
 
 $stripe = new \Stripe\StripeClient($CONFIGCLASS->get('STRIPE_KEY'));
 $link = $stripe->billingPortal->sessions->create([

--- a/src/api/instances/billing/subscribe.php
+++ b/src/api/instances/billing/subscribe.php
@@ -2,7 +2,7 @@
 require_once __DIR__ . '/../../apiHeadSecure.php';
 
 if (!isset($_POST['price_id']) or !isset($_POST['currency'])) die("No price_id provided.");
-if ($AUTH->data['users_userid'] !== $AUTH->data['instance']['instances_billingUser']) die("Sorry, you are not the billing contact for this business, please contact support.");
+if ($AUTH->data['users_userid'] !== $AUTH->data['instance']['instances_billingUser']) die("К сожалению, вы не являетесь плательщиком для этой компании. Свяжитесь с поддержкой.");
 
 \Stripe\Stripe::setApiKey($CONFIGCLASS->get('STRIPE_KEY'));
 

--- a/src/api/instances/editCalendarSettings.php
+++ b/src/api/instances/editCalendarSettings.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../apiHeadSecure.php';
 
-if (!$AUTH->instancePermissionCheck("BUSINESS:BUSINESS_SETTINGS:EDIT")) die("Sorry - you can't access this page");
+if (!$AUTH->instancePermissionCheck("BUSINESS:BUSINESS_SETTINGS:EDIT")) die("К сожалению, у вас нет доступа к этой странице");
 $array = [];
 if (!isset($_POST['formData'])) die("404");
 foreach ($_POST['formData'] as $item) {

--- a/src/api/instances/editInstance.php
+++ b/src/api/instances/editInstance.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../apiHeadSecure.php';
 
-if (!$AUTH->instancePermissionCheck("BUSINESS:BUSINESS_SETTINGS:EDIT")) die("Sorry - you can't access this page");
+if (!$AUTH->instancePermissionCheck("BUSINESS:BUSINESS_SETTINGS:EDIT")) die("К сожалению, у вас нет доступа к этой странице");
 $array = [];
 if (!isset($_POST['formData'])) die("404");
 foreach ($_POST['formData'] as $item) {

--- a/src/api/instances/editInstancePublicSite.php
+++ b/src/api/instances/editInstancePublicSite.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../apiHeadSecure.php';
 
-if (!$AUTH->instancePermissionCheck("BUSINESS:BUSINESS_SETTINGS:EDIT")) die("Sorry - you can't access this page");
+if (!$AUTH->instancePermissionCheck("BUSINESS:BUSINESS_SETTINGS:EDIT")) die("К сожалению, у вас нет доступа к этой странице");
 $array = [];
 if (!isset($_POST['formData'])) die("404");
 foreach ($_POST['formData'] as $item) {

--- a/src/api/instances/editInstanceTrustedDomains.php
+++ b/src/api/instances/editInstanceTrustedDomains.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../apiHeadSecure.php';
 
-if (!$AUTH->instancePermissionCheck("BUSINESS:SETTINGS:EDIT:TRUSTED_DOMAINS")) die("Sorry - you can't access this page");
+if (!$AUTH->instancePermissionCheck("BUSINESS:SETTINGS:EDIT:TRUSTED_DOMAINS")) die("К сожалению, у вас нет доступа к этой странице");
 $array = [];
 if (!isset($_POST['formData'])) die("404");
 foreach ($_POST['formData'] as $item) {

--- a/src/api/instances/signupCodes/new.php
+++ b/src/api/instances/signupCodes/new.php
@@ -11,7 +11,7 @@ if (strlen($array['signupCodes_name']) <1) finish(false, ["code" => "PARAM-ERROR
 $array['instances_id'] = $AUTH->data['instance']['instances_id'];
 
 $DBLIB->where("signupCodes_name", $array['signupCodes_name']);
-if ($DBLIB->getOne("signupCodes",["signupCodes_id"])) finish(false, ["message"=>"Sorry this code is in use"]);
+if ($DBLIB->getOne("signupCodes",["signupCodes_id"])) finish(false, ["message"=>"Этот код уже используется"]);
 
 $insert = $DBLIB->insert("signupCodes", $array);
 if (!$insert) finish(false);

--- a/src/api/login/forgotPassword.php
+++ b/src/api/login/forgotPassword.php
@@ -3,7 +3,7 @@ require_once 'loginAjaxHead.php';
 
 if (isset($_POST['formInput'])) {
     $input = trim(strtolower($GLOBALS['bCMS']->sanitizeString($_POST['formInput'])));
-    if ($input == "") finish(false, ["code" => null, "message" => "No data specified"]);
+    if ($input == "") finish(false, ["code" => null, "message" => "Данные не указаны"]);
     else {
         if (filter_var($input, FILTER_VALIDATE_EMAIL)) $DBLIB->where ("users_email", $input);
         else $DBLIB->where ("users_username", $input);
@@ -15,7 +15,7 @@ if (isset($_POST['formInput'])) {
             finish(true, null, true);
         } else finish(true, null, true);
     }
-} else finish(false, ["code" => null, "message" => "Unknown error"]);
+} else finish(false, ["code" => null, "message" => "Неизвестная ошибка"]);
 
 /** @OA\Post(
  *     path="/login/forgotPassword.php", 

--- a/src/api/login/login.php
+++ b/src/api/login/login.php
@@ -4,7 +4,7 @@ use \Firebase\JWT\JWT;
 if (isset($_POST['formInput']) and isset($_POST['password'])) {
 	$input = trim(strtolower($GLOBALS['bCMS']->sanitizeString($_POST['formInput'])));
     $password = $GLOBALS['bCMS']->sanitizeString($_POST['password']);
-	if ($input == "" || $password == "") finish(false, ["code" => null, "message" => "No data specified"]);
+        if ($input == "" || $password == "") finish(false, ["code" => null, "message" => "Данные не указаны"]);
 	else {
         if (filter_var($input, FILTER_VALIDATE_EMAIL)) $DBLIB->where ("users_email", $input);
         else $DBLIB->where ("users_username", $input);
@@ -34,9 +34,9 @@ if (isset($_POST['formInput']) and isset($_POST['password'])) {
             "loginAttempts_successful" => ($successful ? '1' : '0')
         ]);
 
-        if ($bruteforceattempt) finish(false, ["code" => null, "message" => "Sorry - you've tried too many times to login - please try again in 5 minutes"]);
-        elseif (!$successful) finish(false, ["code" => null, "message" => "Username, email or password incorrect"]);
-        elseif ($user['users_suspended'] != '0') finish(false, ["code" => null, "message" => "User account is suspended"]);
+        if ($bruteforceattempt) finish(false, ["code" => null, "message" => "Слишком много попыток входа — повторите через 5 минут"]);
+        elseif (!$successful) finish(false, ["code" => null, "message" => "Неверные имя пользователя, адрес эл. почты или пароль"]);
+        elseif ($user['users_suspended'] != '0') finish(false, ["code" => null, "message" => "Учётная запись заблокирована"]);
         else {
             if (!$_SESSION['return'] and isset($_SESSION['app-oauth'])) {
                 $token = $GLOBALS['AUTH']->generateToken($user['users_userid'], false, "App OAuth", "app-v1");
@@ -48,7 +48,7 @@ if (isset($_POST['formInput']) and isset($_POST['password'])) {
             }
         }
 	}
-} else finish(false, ["code" => null, "message" => "Unknown error"]);
+} else finish(false, ["code" => null, "message" => "Неизвестная ошибка"]);
 
 /**
  *  @OA\Post(

--- a/src/api/login/signup.php
+++ b/src/api/login/signup.php
@@ -6,8 +6,8 @@ if ($CONFIGCLASS->get("AUTH_SIGNUP_ENABLED") !== 'Enabled') {
 }
 
 if (isset($_POST['name1']) and isset($_POST['password']) and isset($_POST['username']) and isset($_POST['email']) and isset($_POST['name2'])) {
-    if ($AUTH->usernameTaken($GLOBALS['bCMS']->sanitizeString(strtolower($_POST['username'])))) finish(false, ["code" => null, "message" => "Sorry that username is taken, please try another"]);
-    if ($AUTH->emailTaken($GLOBALS['bCMS']->sanitizeString(strtolower($_POST['email'])))) finish(false, ["code" => null, "message" => "Sorry, you already have an account with that email address"]);
+    if ($AUTH->usernameTaken($GLOBALS['bCMS']->sanitizeString(strtolower($_POST['username'])))) finish(false, ["code" => null, "message" => "Такое имя пользователя уже занято, попробуйте другое"]);
+    if ($AUTH->emailTaken($GLOBALS['bCMS']->sanitizeString(strtolower($_POST['email'])))) finish(false, ["code" => null, "message" => "Учётная запись с этим адресом эл. почты уже существует"]);
     $data = Array (
         'users_email' => strtolower($bCMS->sanitizeString($_POST['email'])),
         'users_username' => strtolower($bCMS->sanitizeString($_POST['username'])),
@@ -19,13 +19,13 @@ if (isset($_POST['name1']) and isset($_POST['password']) and isset($_POST['usern
     );
     $data["users_password"] = hash($data['users_hash'], $data['users_salty1'] . $_POST['password'] . $data['users_salty2']);
     $newUser = $DBLIB->insert("users", $data);
-    if (!$newUser) finish(false, ["code" => null, "message" => "Can't create user due to database error"]);
+    if (!$newUser) finish(false, ["code" => null, "message" => "Не удалось создать пользователя из-за ошибки базы данных"]);
     else {
         $bCMS->auditLog("INSERT", "users", json_encode($data), null,$newUser);
         $AUTH->verifyEmail($newUser);
         finish(true);
     }
-} else finish(false, ["code" => null, "message" => "Parameter error"]);
+} else finish(false, ["code" => null, "message" => "Ошибка параметров"]);
 
 /** @OA\Post(
  *     path="/login/signup.php", 

--- a/src/api/projects/crew/crewRoles/apply.php
+++ b/src/api/projects/crew/crewRoles/apply.php
@@ -23,15 +23,15 @@ $DBLIB->where("projectsVacantRoles_open",1);
 $DBLIB->where("(projectsVacantRoles.projectsVacantRoles_deadline IS NULL OR projectsVacantRoles.projectsVacantRoles_deadline >= '" . date("Y-m-d H:i:s") . "')");
 $DBLIB->where("projectsVacantRoles_id",$array['projectsVacantRoles_id']);
 $role = $DBLIB->getOne("projectsVacantRoles",['projectsVacantRoles_id','projectsVacantRoles.projects_id','projects_manager','projects_name','projectsVacantRoles_name',"users.users_userid", "users.users_name1", "users.users_name2", "users.users_email","projectsVacantRoles_firstComeFirstServed","projectsVacantRoles_slots","projectsVacantRoles_slotsFilled","projects.projects_dates_use_end","projects.projects_dates_use_start"]);
-if (!$role) finish(false, ['message' => "Sorry, this role is not available"]);
+if (!$role) finish(false, ['message' => "Эта роль недоступна"]);
 
-if ($role['projectsVacantRoles_firstComeFirstServed'] == 1 and $role['projectsVacantRoles_slotsFilled'] >= $role['projectsVacantRoles_slots']) finish(false, ["message" => "Sorry this role is fully subscribed"]);
+if ($role['projectsVacantRoles_firstComeFirstServed'] == 1 and $role['projectsVacantRoles_slotsFilled'] >= $role['projectsVacantRoles_slots']) finish(false, ["message" => "Свободных мест для этой роли не осталось"]);
 
 $DBLIB->where("projectsVacantRoles_id",$role['projectsVacantRoles_id']);
 $DBLIB->where("users_userid", $AUTH->data['users_userid']);
 $DBLIB->where("projectsVacantRolesApplications_deleted",0);
 $DBLIB->where("projectsVacantRolesApplications_withdrawn",0);
-if ($DBLIB->getOne("projectsVacantRolesApplications",["projectsVacantRolesApplications_id"])) finish(false, ['message' => "Sorry you can't apply twice"]);
+if ($DBLIB->getOne("projectsVacantRolesApplications",["projectsVacantRolesApplications_id"])) finish(false, ['message' => "Вы уже подали заявку на эту роль"]);
 $array['users_userid'] = $AUTH->data['users_userid'];
 $array['projectsVacantRolesApplications_submitted'] = date("Y-m-d H:i:s");
 if ($role['projectsVacantRoles_firstComeFirstServed']) {

--- a/src/assets/template.twig
+++ b/src/assets/template.twig
@@ -130,7 +130,7 @@ ignoreURLs: ['searchUser.php'] // Ignore user searches
                         var errorMessage = "";
                         }
                         bootbox.alert(
-                            "{{ CONFIG.PROJECT_NAME }} encountered an error.{% if CONFIG.LINKS_SUPPORTURL|length > 0 %} <a href='{{ CONFIG.LINKS_SUPPORTURL }}' target='_blank'>Contact Support</a>{% endif %}<br/><br/>" +
+                            "В {{ CONFIG.PROJECT_NAME }} произошла ошибка.{% if CONFIG.LINKS_SUPPORTURL|length > 0 %} <a href='{{ CONFIG.LINKS_SUPPORTURL }}' target='_blank'>Связаться с поддержкой</a>{% endif %}<br/><br/>" +
                             errorMessage,
                         function () {
                             if (reloadIfError) {
@@ -145,7 +145,7 @@ ignoreURLs: ['searchUser.php'] // Ignore user searches
                     console.log(jqXHR, textStatus, errorThrown);
                     console.log("Connection Error");
                     bootbox.alert(
-                        "Sorry we couldn't connect to the internet - please check your connection",
+                        "Не удалось подключиться к интернету — проверьте соединение",
                         function () {
                         if (reloadIfError) {
                             location.reload();
@@ -265,11 +265,11 @@ ignoreURLs: ['searchUser.php'] // Ignore user searches
 					{% endif %}
 					{% if USERDATA.viewSiteAs != false %}
 						<li class="nav-item">
-							<a href="{{ CONFIG.ROOTURL }}/api/account/viewSiteAs_terminate.php" class="nav-link">Back to Admin</a>
+                                                        <a href="{{ CONFIG.ROOTURL }}/api/account/viewSiteAs_terminate.php" class="nav-link">Вернуться к администрированию</a>
 						</li>
 					{% else %}
 						<li class="nav-item">
-							<a href="{{ CONFIG.ROOTURL }}/login/?logout" class="nav-link">Logout</a>
+                                                        <a href="{{ CONFIG.ROOTURL }}/login/?logout" class="nav-link">Выйти</a>
 						</li>
 					{% endif %}
 				</ul>

--- a/src/common/headSecure.php
+++ b/src/common/headSecure.php
@@ -16,7 +16,7 @@ if (!$CONFIG['DEV']) {
         if ($GLOBALS['AUTH']->data['instance']) $scope->setExtra('instances_id', $GLOBALS['AUTH']->data['instance']['instances_id']);
     });
 } elseif (!$AUTH->serverPermissionCheck("USE-DEV") and !$GLOBALS['AUTH']->data['viewSiteAs']) {
-    die("Sorry - you can't use this development version of the site. <a href=\"" . $CONFIG['ROOTURL'] . "/login/?logout\">Logout</a>");
+    die("К сожалению, вам недоступна эта тестовая версия сайта. <a href=\"" . $CONFIG['ROOTURL'] . "/login/?logout\">Выйти</a>");
 }
 
 $PAGEDATA['AUTH'] = $AUTH;

--- a/src/instances/instances_permissions.twig
+++ b/src/instances/instances_permissions.twig
@@ -121,8 +121,8 @@ $(document).ready(function() {
 				if (result == '1') {
 					$("#loading").hide();
                     location.reload();
-				} else {
-					bootbox.alert(result + "Sorry - Operation could not be completed! Please try again!", function() {
+                                } else {
+                                        bootbox.alert(result + " К сожалению, выполнить операцию не удалось. Повторите попытку.", function() {
 						location.reload();
 					});
 				}
@@ -137,9 +137,9 @@ $(document).ready(function() {
 		let cautionText = checkbox.data("cautiontext")
 		//show a popup if this is a signup code permission
 		if (checkbox.is(":checked") && cautionText !== null && cautionText.length > 0) {
-			bootbox.confirm({
-				title: "Warning - potential privilege escalation",
-				message: cautionText + "<br /><br />This permission is normally only enabled for administrators in a business. Are you sure you want to enable it?",
+                        bootbox.confirm({
+                                title: "Предупреждение — возможно повышение привилегий",
+                                message: cautionText + "<br /><br />Обычно это разрешение включают только администраторы компании. Вы уверены, что хотите его включить?",
 				buttons: {
 					confirm: {
 						label: 'Да',

--- a/src/instances/signupCodes.twig
+++ b/src/instances/signupCodes.twig
@@ -124,7 +124,7 @@
                         <input type="text" class="form-control" id="signupCodes_name" name="signupCodes_name" aria-describedby="code-help">
                         <small id="code-help" class="form-text text-muted">Enter the code itself</small>
                         <div class="valid-feedback">Code is available</div>
-                        <div class="invalid-feedback" id="signupCodes_name_invalid">Sorry - that code is taken</div>
+                        <div class="invalid-feedback" id="signupCodes_name_invalid">Этот код уже используется</div>
                     </div>
                     <div class="form-group">
                         <label for="signupCodes_role">Role *</label>
@@ -158,7 +158,7 @@
                 $("#signupCodes_name").val(result);
                 ajaxcall("instances/signupCodes/taken.php?signupCode=" + result, {}, (taken) => {
                     if (taken.response.taken) {
-                        $("#signupCodes_name_invalid").text("Sorry - that code is taken")
+                        $("#signupCodes_name_invalid").text("Этот код уже используется")
                         $("#signupCodes_name").removeClass('is-valid')
                         $("#signupCodes_name").addClass('is-invalid')
                     } else {
@@ -222,7 +222,7 @@
                             result = result.replace(/[^a-z0-9]/gi,'');
                             ajaxcall("instances/signupCodes/taken.php?signupCode=" + result, {}, function (taken) {
                                 if (taken.response.taken && currentValue != result) {
-                                    bootbox.alert("Sorry - that code is taken");
+                                    bootbox.alert("Этот код уже используется");
                                 } else {
                                     bootbox.prompt({
                                         title: "Notes",

--- a/src/login/error.twig
+++ b/src/login/error.twig
@@ -1,5 +1,5 @@
 {% extends "login/login_template.twig" %}
 {% block content %}
     <p>{{ ERROR }}</p>
-    <a href="?" class="btn btn-success">Try Again</a>
+    <a href="?" class="btn btn-success">Попробовать снова</a>
 {% endblock %}

--- a/src/login/index.php
+++ b/src/login/index.php
@@ -3,7 +3,7 @@ require_once __DIR__ . '/../common/head.php';
 
 use \Firebase\JWT\JWT;
 
-$PAGEDATA['pageConfig'] = ["TITLE" => "Login"];
+$PAGEDATA['pageConfig'] = ["TITLE" => "Вход"];
 $PAGEDATA['signupEnabled'] = $CONFIGCLASS->get("AUTH_SIGNUP_ENABLED") == 'Enabled';
 $PAGEDATA['googleAuthAvailable'] = $CONFIGCLASS->get("AUTH_PROVIDERS_GOOGLE_KEYS_ID") != false and $CONFIGCLASS->get("AUTH_PROVIDERS_GOOGLE_KEYS_SECRET") != false;
 $PAGEDATA['microsoftAuthAvailable'] = $CONFIGCLASS->get("AUTH_PROVIDERS_MICROSOFT_APP_ID") != false and $CONFIGCLASS->get("AUTH_PROVIDERS_MICROSOFT_KEYS_SECRET") != false;

--- a/src/login/login_template.twig
+++ b/src/login/login_template.twig
@@ -10,7 +10,7 @@
 		<meta property="og:type" content="website"/>
 		<meta property="og:url" content="/login/"/>
 		<meta property="og:site_name" content="{{ CONFIG.PROJECT_NAME }}"/>
-		<meta property="og:description" content="{{ CONFIG.PROJECT_NAME }} admin login"/>
+                <meta property="og:description" content="{{ CONFIG.PROJECT_NAME }} — вход администратора"/>
 
 
 		<script src="{{ CONFIG.ROOTURL }}/static-assets/vendor/jquery/jquery-3.6.0.min.js"></script>
@@ -134,17 +134,17 @@
 					<div id="masterBox">
 						<a href="{{CONFIG.ROOTURL}}/login/?"><img src="{{ CONFIG.ROOTURL}}/static-assets/img/login/logo.svg" style="height:5em; margin-bottom: 15px; margin-top: 10px;" id="bCMSLogoHeader"/></a>
 						<div class="alert alert-danger" style="border: 0px; text-align: left; display: none;" id="defaultAccountEnabledWarning">
-							<h4>The default super administrator account for {{ CONFIG.PROJECT_NAME }} is enabled</h4>
-							<p>Login to this account and change the password. Default username is <strong>username</strong> and password is <strong>password!</strong></p>
-						</div>
-						{% if CONFIG.DEV %}
-							<div class="alert alert-warning" style="border: 0px; text-align: left;">
-								<h4>{{ CONFIG.PROJECT_NAME }} is running in development mode, and should only be used for testing purposes</h4>
-								<p>Default username is <strong>username</strong> and password is <strong>password!</strong></p>
-								<a type="button" href="/" onclick="javascript:event.target.port=8082" target="_blank" class="btn btn-info btn-sm">Database Editor</a>
-								<a type="button" href="/" onclick="javascript:event.target.port=8083" target="_blank" class="btn btn-info btn-sm">Email Inbox</a>
-							</div>
-						{% endif %}
+                                                        <h4>Учётная запись супер-администратора по умолчанию для {{ CONFIG.PROJECT_NAME }} включена</h4>
+                                                        <p>Войдите в эту учётную запись и смените пароль. Имя пользователя по умолчанию — <strong>username</strong>, пароль — <strong>password!</strong></p>
+                                                </div>
+                                                {% if CONFIG.DEV %}
+                                                        <div class="alert alert-warning" style="border: 0px; text-align: left;">
+                                                                <h4>{{ CONFIG.PROJECT_NAME }} работает в режиме разработки и предназначен только для тестирования</h4>
+                                                                <p>Имя пользователя по умолчанию — <strong>username</strong>, пароль — <strong>password!</strong></p>
+                                                                <a type="button" href="/" onclick="javascript:event.target.port=8082" target="_blank" class="btn btn-info btn-sm">Редактор базы данных</a>
+                                                                <a type="button" href="/" onclick="javascript:event.target.port=8083" target="_blank" class="btn btn-info btn-sm">Почтовый ящик</a>
+                                                        </div>
+                                                {% endif %}
 						{% block content %}{% endblock %}
 					</div>
 				</div>
@@ -157,7 +157,7 @@
 					<div class="col-8" style="text-align: right;">
                     {# About link to adam-rms.com removed for local-only build #}
 {% if CONFIG.LINKS_TERMSOFSERVICEURL %}
-	<a href="{{ CONFIG.LINKS_TERMSOFSERVICEURL }}" target="_blank">Terms &amp; Privacy</a>
+        <a href="{{ CONFIG.LINKS_TERMSOFSERVICEURL }}" target="_blank">Условия и конфиденциальность</a>
 {% endif %}
 
 					</div>

--- a/src/login/oauth/google.php
+++ b/src/login/oauth/google.php
@@ -3,7 +3,7 @@ require_once __DIR__ . '/../../common/head.php';
 
 use \Firebase\JWT\JWT;
 
-$PAGEDATA['pageConfig'] = ["TITLE" => "Login with Google"];
+$PAGEDATA['pageConfig'] = ["TITLE" => "Вход через Google"];
 $PAGEDATA['googleAuthAvailable'] = $CONFIGCLASS->get("AUTH_PROVIDERS_GOOGLE_KEYS_ID") != false and $CONFIGCLASS->get("AUTH_PROVIDERS_GOOGLE_KEYS_SECRET") != false;
 
 if (!$PAGEDATA['googleAuthAvailable']) {
@@ -37,7 +37,7 @@ try {
 	$adapter->authenticate();
 } catch (\Exception $e) {
 	//Issue with auth state, which is a problem with the user's browser. We can't do anything about this, so just show an error
-	$PAGEDATA['ERROR'] = "Sorry, something went wrong authenticating with Google.";
+        $PAGEDATA['ERROR'] = "К сожалению, произошла ошибка при аутентификации через Google.";
 	die($TWIG->render('login/error.twig', $PAGEDATA));
 }
 $accessToken = $adapter->getAccessToken(); //We don't actually use this - we could in theory just drop it?
@@ -45,12 +45,12 @@ $userProfile = $adapter->getUserProfile();
 $adapter->disconnect(); //Disconnect this authentication from the session, so they can pick another account
 if (strlen($userProfile->identifier) < 1) {
 	//ISSUE WITH PROFILE
-	$PAGEDATA['ERROR'] = "Sorry, something went wrong authenticating with Google";
+        $PAGEDATA['ERROR'] = "К сожалению, произошла ошибка при аутентификации через Google";
 	echo $TWIG->render('login/error.twig', $PAGEDATA);
 	exit;
 }
 if (strlen($userProfile->emailVerified) < 1) {
-	$PAGEDATA['ERROR'] = "Please verify your email with Google to continue to login";
+        $PAGEDATA['ERROR'] = "Подтвердите адрес эл. почты в Google, чтобы продолжить вход";
 	echo $TWIG->render('login/error.twig', $PAGEDATA);
 	exit;
 }
@@ -60,7 +60,7 @@ $DBLIB->where("users_deleted", 0);
 $user = $DBLIB->getOne("users", ["users.users_suspended", "users.users_userid", "users.users_hash", "users.users_emailVerified", "users.users_email"]);
 if ($user) {
 	if ($user['users_suspended'] != '0') {
-		$PAGEDATA['ERROR'] = "Sorry, your user account is suspended";
+                $PAGEDATA['ERROR'] = "К сожалению, ваша учётная запись заблокирована";
 		echo $TWIG->render('login/error.twig', $PAGEDATA);
 		exit;
 	}
@@ -87,7 +87,7 @@ if ($user) {
 	$DBLIB->where("users_email", strtolower($userProfile->emailVerified));
 	$user = $DBLIB->getOne("users", ["users.users_suspended", "users.users_userid", "users.users_hash", "users.users_emailVerified"]);
 	if ($user) {
-		$PAGEDATA['ERROR'] = "An AdamRMS account associated with the email address you selected has been found. Please login again using your AdamRMS username & password to link your account to a Google Account in AdamRMS account settings";
+                $PAGEDATA['ERROR'] = "Мы нашли учётную запись AdamRMS, связанную с выбранным адресом эл. почты. Войдите снова, используя имя пользователя и пароль AdamRMS, чтобы привязать аккаунт к Google в настройках AdamRMS.";
 		echo $TWIG->render('login/error.twig', $PAGEDATA);
 		exit;
 	}
@@ -95,7 +95,7 @@ if ($user) {
 
 // They don't have an account already. Check whether we can create them an account.
 if ($CONFIGCLASS->get("AUTH_SIGNUP_ENABLED") !== 'Enabled') {
-	$PAGEDATA['ERROR'] = "We couldn't find an existing account and signups are disabled. Please contact your business administrator to sign up.";
+        $PAGEDATA['ERROR'] = "Мы не нашли существующую учётную запись, а регистрация отключена. Свяжитесь с администратором компании, чтобы зарегистрироваться.";
 	echo $TWIG->render('login/error.twig', $PAGEDATA);
 	exit;
 }
@@ -116,13 +116,13 @@ $data = array(
 );
 $newUser = $DBLIB->insert("users", $data);
 if (!$newUser) {
-	$PAGEDATA['ERROR'] = "Sorry something went wrong trying to create a new user account";
+        $PAGEDATA['ERROR'] = "К сожалению, не удалось создать новую учётную запись";
 	echo $TWIG->render('login/error.twig', $PAGEDATA);
 	exit;
 }
 $bCMS->auditLog("INSERT", "users", json_encode($data), null, $newUser);
 if (!$_SESSION['return'] and isset($_SESSION['app-oauth'])) {
-	$PAGEDATA['ERROR'] = "Account created - please restart app and login again";
+        $PAGEDATA['ERROR'] = "Учётная запись создана — перезапустите приложение и войдите снова";
 	echo $TWIG->render('login/error.twig', $PAGEDATA);
 	exit;
 } else {

--- a/src/login/oauth/microsoft.php
+++ b/src/login/oauth/microsoft.php
@@ -3,7 +3,7 @@ require_once __DIR__ . '/../../common/head.php';
 
 use \Firebase\JWT\JWT;
 
-$PAGEDATA['pageConfig'] = ["TITLE" => "Login with Microsoft"];
+$PAGEDATA['pageConfig'] = ["TITLE" => "Вход через Microsoft"];
 $PAGEDATA['microsoftAuthAvailable'] = $CONFIGCLASS->get("AUTH_PROVIDERS_MICROSOFT_APP_ID") != false and $CONFIGCLASS->get("AUTH_PROVIDERS_MICROSOFT_KEYS_SECRET") != false;
 
 if (!$PAGEDATA['microsoftAuthAvailable']) {
@@ -27,7 +27,7 @@ try {
 	$adapter->authenticate();
 } catch (\Exception $e) {
 	//Issue with auth state, which is a problem with the user's browser. We can't do anything about this, so just show an error
-	$PAGEDATA['ERROR'] = "Sorry, something went wrong authenticating with Microsoft.";
+        $PAGEDATA['ERROR'] = "К сожалению, произошла ошибка при аутентификации через Microsoft.";
 	die($TWIG->render('login/error.twig', $PAGEDATA));
 }
 $accessToken = $adapter->getAccessToken(); //We don't actually use this - we could in theory just drop it?
@@ -35,7 +35,7 @@ $userProfile = $adapter->getUserProfile();
 $adapter->disconnect(); //Disconnect this authentication from the session, so they can pick another account
 if (strlen($userProfile->identifier) < 1) {
 	//ISSUE WITH PROFILE
-	$PAGEDATA['ERROR'] = "Sorry, something went wrong authenticating with Microsoft";
+        $PAGEDATA['ERROR'] = "К сожалению, произошла ошибка при аутентификации через Microsoft";
 	echo $TWIG->render('login/error.twig', $PAGEDATA);
 	exit;
 }
@@ -45,7 +45,7 @@ $DBLIB->where("users_deleted", 0);
 $user = $DBLIB->getOne("users", ["users.users_suspended", "users.users_userid", "users.users_hash", "users.users_email"]);
 if ($user) {
 	if ($user['users_suspended'] != '0') {
-		$PAGEDATA['ERROR'] = "Sorry, your user account is suspended";
+                $PAGEDATA['ERROR'] = "К сожалению, ваша учётная запись заблокирована";
 		echo $TWIG->render('login/error.twig', $PAGEDATA);
 		exit;
 	}
@@ -60,7 +60,7 @@ if ($user) {
 	$DBLIB->where("users_email", strtolower($userProfile->email));
 	$user = $DBLIB->getOne("users", ["users.users_suspended", "users.users_userid", "users.users_hash"]);
 	if ($user) {
-		$PAGEDATA['ERROR'] = "An AdamRMS account associated with the email address you selected has been found. Please login again using your AdamRMS username & password to link your account to a Microsoft Account in AdamRMS account settings";
+                $PAGEDATA['ERROR'] = "Мы нашли учётную запись AdamRMS, связанную с выбранным адресом эл. почты. Войдите снова, используя имя пользователя и пароль AdamRMS, чтобы привязать аккаунт к Microsoft в настройках AdamRMS.";
 		echo $TWIG->render('login/error.twig', $PAGEDATA);
 		exit;
 	}
@@ -68,7 +68,7 @@ if ($user) {
 
 // They don't have an account already. Check whether we can create them an account.
 if ($CONFIGCLASS->get("AUTH_SIGNUP_ENABLED") !== 'Enabled') {
-	$PAGEDATA['ERROR'] = "We couldn't find an existing account and signups are disabled. Please contact your business administrator to sign up.";
+        $PAGEDATA['ERROR'] = "Мы не нашли существующую учётную запись, а регистрация отключена. Свяжитесь с администратором компании, чтобы зарегистрироваться.";
 	echo $TWIG->render('login/error.twig', $PAGEDATA);
 	exit;
 }
@@ -89,13 +89,13 @@ $data = array(
 );
 $newUser = $DBLIB->insert("users", $data);
 if (!$newUser) {
-	$PAGEDATA['ERROR'] = "Sorry something went wrong trying to create a new user account";
+        $PAGEDATA['ERROR'] = "К сожалению, не удалось создать новую учётную запись";
 	echo $TWIG->render('login/error.twig', $PAGEDATA);
 	exit;
 }
 $bCMS->auditLog("INSERT", "users", json_encode($data), null, $newUser);
 if (!$_SESSION['return'] and isset($_SESSION['app-oauth'])) {
-	$PAGEDATA['ERROR'] = "Account created - please restart app and login again";
+        $PAGEDATA['ERROR'] = "Учётная запись создана — перезапустите приложение и войдите снова";
 	echo $TWIG->render('login/error.twig', $PAGEDATA);
 	exit;
 } else {

--- a/src/maintenance/barcode.twig
+++ b/src/maintenance/barcode.twig
@@ -183,7 +183,7 @@
                         barcodeRequestInProgress = false
                     });
                 } else {
-                    bootbox.alert("Sorry location not found");
+                    bootbox.alert("Локация не найдена");
                     barcodeRequestInProgress = false
                 }
             });

--- a/src/project/project_assetsBoard.twig
+++ b/src/project/project_assetsBoard.twig
@@ -256,7 +256,7 @@
                 error: function (jqXHR, textStatus, errorThrown) {
                     console.log(jqXHR, textStatus, errorThrown);
                     console.log("Connection Error");
-                    bootbox.alert('Sorry we couldn\'t connect to the internet - please check your connection', function () {
+                    bootbox.alert('Не удалось подключиться к интернету — проверьте соединение', function () {
                         location.reload();
                     });
                 }

--- a/src/project/project_index.twig
+++ b/src/project/project_index.twig
@@ -1117,11 +1117,11 @@
                             message: message + "</table>",
                             buttons: {
                                 cancel: {
-                                    label: 'No - cancel date change',
+                                    label: 'Нет — отменить изменение даты',
                                     className: 'btn-success'
                                 },
                                 confirm: {
-                                    label: 'Yes',
+                                    label: 'Да',
                                     className: 'btn-danger'
                                 }
                             },
@@ -1139,7 +1139,7 @@
                                         changeProjectDeliverDates(start, end);
                                     });
                                     {% else %}
-                                    bootbox.alert("Sorry - you don't have permission to remove these assets");
+                                    bootbox.alert("К сожалению, у вас нет прав на удаление этих активов");
                                     {% endif %}
                                 }
                             }

--- a/src/server/users.twig
+++ b/src/server/users.twig
@@ -251,7 +251,7 @@
                             if (result == '1') {
                                 $("#loadingoverlay").hide();
                             } else {
-                                bootbox.alert("Sorry - Operation could not be completed! Please reload the page")
+                                bootbox.alert("К сожалению, не удалось выполнить операцию. Перезагрузите страницу")
                             }
                         }
                     });
@@ -264,11 +264,11 @@
                         url: "{{ CONFIG.ROOTURL }}/api/account/suspend.php?userid=" + $(this).data("userid") + '&suspendval=' + $(this).data("suspendval"),
                         success: function (result) {
                             if (result == '1') {
-                                bootbox.alert("Success", function () {
+                                bootbox.alert("Успешно", function () {
                                     location.reload();
                                 });
                             } else {
-                                bootbox.alert("Sorry - Operation could not be completed! Please reload the page", function () {
+                                bootbox.alert("К сожалению, не удалось выполнить операцию. Перезагрузите страницу", function () {
                                     location.reload();
                                 });
                             }

--- a/src/user.twig
+++ b/src/user.twig
@@ -241,23 +241,23 @@
                         {% endif %}
                         {% if user.users_userid == USERDATA.users_userid %}
                         <div class="tab-pane p-3" id="passwordsocial">
-                            <h2>Password</h2>
+                            <h2>Пароль</h2>
                             <div class="form-group">
-                                <label for="username">Current Password</label>
-                                <input type="password" placeholder="Current Password" class="form-control" id="current_pass" />
+                                <label for="username">Текущий пароль</label>
+                                <input type="password" placeholder="Текущий пароль" class="form-control" id="current_pass" />
                             </div>
                             <div class="form-group">
                                 <label for="username">Новый пароль</label>
                                 <input type="password" placeholder="Новый пароль" class="form-control" id="passnew" /><br/>
                                 <input type="password" placeholder="Подтвердите новый пароль" class="form-control" id="passconf" />
                             </div>
-                            <button id="save-password-settings" class="btn btn-default">Change Password</button>
+                            <button id="save-password-settings" class="btn btn-default">Сменить пароль</button>
                             <script>
                                 $(document).ready(function() {
                                     $('#save-password-settings').on('click', function() {
                                         if ($('#passnew').val() != $('#passconf').val()) {
-                                            bootbox.alert("Sorry - Your new password's don't match!");
-                                        } else if ($("#passnew").val().length < 6) bootbox.alert("Sorry - Your password is too short!");
+                                            bootbox.alert("Новые пароли не совпадают");
+                                        } else if ($("#passnew").val().length < 6) bootbox.alert("Пароль слишком короткий");
                                         else {
                                             ajaxcall("account/changePass.php", {
                                                 "users_userid": "{{ user.users_userid }}",
@@ -271,11 +271,11 @@
                                 });
                             </script>
                             <hr/>
-                            <h2>Authentication Providers</h2>
+                            <h2>Провайдеры аутентификации</h2>
                             {% if googleAuthAvailable %}
                                 <h4>Google</h4>
                                 {% if user.users_oauth_googleid %}
-                                    <button class="btn btn-danger" id="disconnectOAuthGoogle"><i class="fab fa-google"></i> Disconnect Google Account</button>
+                                    <button class="btn btn-danger" id="disconnectOAuthGoogle"><i class="fab fa-google"></i> Отключить аккаунт Google</button>
                                     <script>
                                         $(document).ready(function() {
                                             $('#disconnectOAuthGoogle').on('click', function() {
@@ -289,13 +289,13 @@
                                         });
                                     </script>
                                 {% else %}
-                                    <a href="{{ CONFIG.ROOTURL }}/api/account/oauth-link/google.php" class="btn btn-default"><i class="fab fa-google"></i> Link to Google Account</a>
+                                    <a href="{{ CONFIG.ROOTURL }}/api/account/oauth-link/google.php" class="btn btn-default"><i class="fab fa-google"></i> Привязать аккаунт Google</a>
                                 {% endif %}
                             {% endif %}
                             {% if microsoftAuthAvailable %}
                                 <h4>Microsoft</h4>
                                 {% if user.users_oauth_microsoftid %}
-                                    <button class="btn btn-danger" id="disconnectOAuthMicrosoft"><i class="fab fa-microsoft"></i> Disconnect Microsoft Account</button>
+                                    <button class="btn btn-danger" id="disconnectOAuthMicrosoft"><i class="fab fa-microsoft"></i> Отключить аккаунт Microsoft</button>
                                     <script>
                                         $(document).ready(function() {
                                             $('#disconnectOAuthMicrosoft').on('click', function() {


### PR DESCRIPTION
## Summary
- translate login templates, OAuth flows, and navigation messaging to Russian
- localize user profile, permissions, and global error prompts throughout the UI
- update API error responses across authentication, account, asset, and instance endpoints to Russian text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df5e953c588326b7d33c4520d174e7